### PR TITLE
feat: add post-delivery-hook + --set-field for automated cost tracking

### DIFF
--- a/.gaai/core/scripts/backlog-scheduler.sh
+++ b/.gaai/core/scripts/backlog-scheduler.sh
@@ -27,6 +27,11 @@ set -euo pipefail
 #                   blocked by lower-priority dependencies)
 #   --set-status <id> <status>  Update a story's status in the
 #                   YAML file. Requires file path (not --stdin).
+#   --set-field <id> <field> <value>  Set any field on a backlog
+#                   item. Updates if exists, inserts after delivery
+#                   metadata fields if not. Numbers and null/true/
+#                   false stay bare; strings are auto-quoted.
+#                   Requires file path (not --stdin).
 #   --stdin         Read YAML from stdin instead of file
 #
 # Inputs:
@@ -49,6 +54,9 @@ BACKLOG_FILE=""
 FROM_STDIN=false
 SET_STATUS_ID=""
 SET_STATUS_VAL=""
+SET_FIELD_ID=""
+SET_FIELD_NAME=""
+SET_FIELD_VAL=""
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -68,10 +76,22 @@ while [[ $# -gt 0 ]]; do
       fi
       shift 3
       ;;
+    --set-field)
+      MODE="set-field"
+      SET_FIELD_ID="${2:-}"
+      SET_FIELD_NAME="${3:-}"
+      SET_FIELD_VAL="${4:-}"
+      if [[ -z "$SET_FIELD_ID" || -z "$SET_FIELD_NAME" ]]; then
+        >&2 echo "Error: --set-field requires <id> <field> <value>"
+        >&2 echo "Usage: $0 --set-field <id> <field> <value> <backlog-active-yaml>"
+        exit 1
+      fi
+      shift 4
+      ;;
     --stdin)      FROM_STDIN=true;   shift ;;
     -*)
       >&2 echo "Unknown option: $1"
-      >&2 echo "Usage: $0 [--next|--list|--ready-ids|--graph|--conflicts|--set-status <id> <status>] [--stdin] [<backlog-active-yaml>]"
+      >&2 echo "Usage: $0 [--next|--list|--ready-ids|--graph|--conflicts|--set-status <id> <status>|--set-field <id> <field> <value>] [--stdin] [<backlog-active-yaml>]"
       exit 1
       ;;
     *)
@@ -82,11 +102,11 @@ while [[ $# -gt 0 ]]; do
 done
 
 # ── Validate inputs ──────────────────────────────────────────
-if [[ "$MODE" == "set-status" ]]; then
-  # set-status always operates on a file (not stdin)
+if [[ "$MODE" == "set-status" || "$MODE" == "set-field" ]]; then
+  # set-status/set-field always operate on a file (not stdin)
   if [[ -z "$BACKLOG_FILE" ]]; then
-    >&2 echo "Error: --set-status requires a backlog file path"
-    >&2 echo "Usage: $0 --set-status <id> <status> <backlog-active-yaml>"
+    >&2 echo "Error: --$MODE requires a backlog file path"
+    >&2 echo "Usage: $0 --$MODE ... <backlog-active-yaml>"
     exit 1
   fi
   if [[ ! -f "$BACKLOG_FILE" ]]; then
@@ -146,6 +166,87 @@ with open(file_path, 'w') as f:
 
 print(f'{target_id} -> {new_status}')
 " "$BACKLOG_FILE" "$SET_STATUS_ID" "$SET_STATUS_VAL"
+  exit $?
+fi
+
+# ── set-field mode: set any field on a backlog item ──────────
+if [[ "$MODE" == "set-field" ]]; then
+  python3 -c "
+import sys, re
+
+file_path, target_id, field_name, field_value = sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4]
+
+with open(file_path, 'r') as f:
+    lines = f.readlines()
+
+# Find target item block boundaries
+block_start = -1
+block_end = len(lines)
+
+for i, line in enumerate(lines):
+    stripped = line.strip()
+    if re.match(r'-\s+id:\s+' + re.escape(target_id) + r'\s*$', stripped):
+        block_start = i
+        continue
+    if block_start >= 0 and re.match(r'-\s+id:\s+', stripped):
+        block_end = i
+        break
+
+if block_start < 0:
+    print(f'Error: item {target_id} not found', file=sys.stderr)
+    sys.exit(1)
+
+# Format value: numbers stay bare, null/true/false/[] stay bare, strings get quoted
+try:
+    float(field_value)
+    formatted = field_value
+except ValueError:
+    if field_value in ('null', 'true', 'false', '[]'):
+        formatted = field_value
+    else:
+        # Escape inner double quotes and wrap
+        formatted = '\"' + field_value.replace('\\\\', '\\\\\\\\').replace('\"', '\\\\\"') + '\"'
+
+# Look for existing field within the block
+field_found = False
+for i in range(block_start + 1, block_end):
+    m = re.match(r'^(\s+)' + re.escape(field_name) + r':\s', lines[i])
+    if m:
+        indent = m.group(1)
+        lines[i] = f'{indent}{field_name}: {formatted}\n'
+        field_found = True
+        break
+
+if not field_found:
+    # Determine indentation from existing fields
+    indent = '    '
+    for i in range(block_start + 1, block_end):
+        m2 = re.match(r'^(\s+)\w', lines[i])
+        if m2:
+            indent = m2.group(1)
+            break
+
+    # Insertion order: after the last delivery-metadata field present,
+    # or after status: if none exist
+    DELIVERY_FIELDS = ['status', 'cost_usd', 'human_md_estimate', 'human_cost_usd', 'started_at', 'completed_at', 'pr_url', 'pr_number', 'pr_status']
+    insert_after = -1
+    for i in range(block_start + 1, block_end):
+        fm = re.match(r'^\s+(\w+):', lines[i])
+        if fm and fm.group(1) in DELIVERY_FIELDS:
+            insert_after = i
+
+    if insert_after < 0:
+        # Fallback: insert after the id line
+        insert_after = block_start
+
+    new_line = f'{indent}{field_name}: {formatted}\n'
+    lines.insert(insert_after + 1, new_line)
+
+with open(file_path, 'w') as f:
+    f.writelines(lines)
+
+print(f'{target_id}.{field_name} = {formatted}')
+" "$BACKLOG_FILE" "$SET_FIELD_ID" "$SET_FIELD_NAME" "$SET_FIELD_VAL"
   exit $?
 fi
 

--- a/.gaai/core/scripts/post-delivery-hook.sh
+++ b/.gaai/core/scripts/post-delivery-hook.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# ── GAAI Stop Hook — auto-record cost_usd after delivery session ─────────────
+#
+# Description:
+#   Fires on Claude Code Stop event. If a delivery just completed (detects
+#   "chore({id}): done [delivery]" in recent git log), extracts total_cost_usd
+#   from the session transcript and writes it to the backlog.
+#
+# Usage:
+#   Invoked automatically by Claude Code via .claude/settings.json hooks.Stop.
+#   Input: JSON via stdin (hook_event_name, session_id, transcript_path).
+#
+# Outputs:
+#   Updates cost_usd field in active.backlog.yaml + commits + pushes to staging.
+#   Exits 0 always (non-blocking — cost is best-effort).
+#
+# Exit codes:
+#   0 — always (errors are logged to stderr, never block the session)
+# ─────────────────────────────────────────────────────────────────────────────
+
+set -uo pipefail
+
+PROJECT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+BACKLOG="$PROJECT_DIR/.gaai/project/contexts/backlog/active.backlog.yaml"
+SCHEDULER="$PROJECT_DIR/.gaai/core/scripts/backlog-scheduler.sh"
+TARGET_BRANCH="staging"
+
+# ── 1. Read hook input ────────────────────────────────────────────────────────
+input=$(cat 2>/dev/null) || { exit 0; }
+
+transcript_path=$(echo "$input" | python3 -c "
+import json, sys
+try:
+    d = json.load(sys.stdin)
+    print(d.get('transcript_path', ''))
+except:
+    print('')
+" 2>/dev/null) || transcript_path=""
+
+# ── 2. Find story ID from recent git log ──────────────────────────────────────
+cd "$PROJECT_DIR" || exit 0
+
+git pull origin "$TARGET_BRANCH" --ff-only --quiet 2>/dev/null || true
+
+story_id=$(git log --oneline -20 2>/dev/null \
+  | grep -oE 'chore\([A-Z][0-9]+S[0-9]+\): done \[delivery\]' \
+  | head -1 \
+  | grep -oE '[A-Z][0-9]+S[0-9]+') || story_id=""
+
+if [[ -z "$story_id" ]]; then
+  exit 0  # No delivery just completed — skip silently
+fi
+
+# ── 3. Skip if cost_usd already set ──────────────────────────────────────────
+existing_cost=$(grep -A 15 "id: $story_id" "$BACKLOG" 2>/dev/null \
+  | grep 'cost_usd:' \
+  | head -1 \
+  | sed 's/.*cost_usd: *//' \
+  | tr -d ' \n') || existing_cost=""
+
+if [[ -n "$existing_cost" && "$existing_cost" != "null" ]]; then
+  exit 0  # Already recorded — idempotent
+fi
+
+# ── 4. Extract cost from transcript ──────────────────────────────────────────
+cost=""
+
+if [[ -n "$transcript_path" && -f "$transcript_path" ]]; then
+  cost=$(python3 - "$transcript_path" <<'PYEOF'
+import json, sys
+
+path = sys.argv[1]
+total_cost = 0.0
+
+try:
+    with open(path, 'r') as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                d = json.loads(line)
+            except:
+                continue
+            # Stream-json result message
+            if d.get('type') == 'result':
+                c = d.get('total_cost_usd') or d.get('cost_usd') or 0
+                if c:
+                    total_cost = float(c)
+            # Transcript assistant message with costUSD field
+            if d.get('role') == 'assistant':
+                c = d.get('costUSD') or d.get('cost_usd') or 0
+                if c:
+                    total_cost += float(c)
+except Exception as e:
+    sys.stderr.write(f'[post-delivery-hook] transcript parse error: {e}\n')
+
+if total_cost > 0:
+    print(round(total_cost, 2))
+PYEOF
+  2>/dev/null) || cost=""
+fi
+
+if [[ -z "$cost" || "$cost" == "0" ]]; then
+  exit 0  # Could not extract cost — skip silently
+fi
+
+# ── 5. Update backlog + commit + push ─────────────────────────────────────────
+(
+  "$SCHEDULER" --set-field "$story_id" cost_usd "$cost" "$BACKLOG" 2>/dev/null || exit 1
+  git add "$BACKLOG" 2>/dev/null || exit 1
+  git diff --cached --quiet 2>/dev/null && exit 0  # No change
+  git commit -m "chore($story_id): cost_usd=$cost [stop-hook]" --quiet 2>/dev/null || exit 1
+  git push origin "$TARGET_BRANCH" --quiet 2>/dev/null || true
+  echo "[post-delivery-hook] cost_usd=$cost recorded for $story_id" >&2
+) || echo "[post-delivery-hook] Warning: could not write cost_usd for $story_id" >&2
+
+exit 0

--- a/.github/workflows/validate-structure.yml
+++ b/.github/workflows/validate-structure.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Validate .gaai/ structure
-        run: bash .gaai/scripts/health-check.sh
+        run: bash .gaai/core/scripts/health-check.sh
 
       - name: Validate artefact references
-        run: bash .gaai/scripts/artefact-sync.sh
+        run: bash .gaai/core/scripts/artefact-sync.sh


### PR DESCRIPTION
## Summary
- Add `scripts/post-delivery-hook.sh` — Claude Code Stop hook that auto-records `cost_usd` in the backlog after delivery sessions
- Add `--set-field` mode to `scripts/backlog-scheduler.sh` — generic field setter used by the hook (and usable standalone)

## Context
These were implemented in the callibrate-core project but lost during the v2.0.0 subtree replacement (the delete-then-add didn't preserve project-local additions to `core/`). Contributing upstream so they survive future subtree pulls and the `_subtree-export` auto-generation includes them.

## What the hook does
1. Fires on Claude Code `Stop` event
2. Detects if a delivery just completed (`chore({id}): done [delivery]` in git log)
3. Extracts `total_cost_usd` from the session transcript (JSONL)
4. Writes `cost_usd` to the backlog via `backlog-scheduler.sh --set-field`
5. Commits + pushes (best-effort, never blocks)

## Test plan
- [x] `--set-field` tested: `backlog-scheduler.sh --set-field E09S05 cost_usd 3.73` → updates YAML correctly
- [x] Hook verified: path in `.claude/settings.json` resolves, script is executable
- [ ] End-to-end: next daemon delivery should auto-record cost_usd

🤖 Generated with [Claude Code](https://claude.com/claude-code)