### PR TITLE
feat: friction log system + context lifecycle alignment

### DIFF
--- a/.gaai/core/agents/sub-agents/implementation.sub-agent.md
+++ b/.gaai/core/agents/sub-agents/implementation.sub-agent.md
@@ -74,6 +74,17 @@ The artefact must include:
 - Rules applied
 - Known risks or limitations
 - Specialist sub-agents invoked (if any) and their outputs
+- **Friction Log** (if any friction occurred — omit entirely if delivery was smooth):
+
+  | # | phase | type | description | workaround | signal |
+  |---|-------|------|-------------|------------|--------|
+
+  Controlled vocabulary:
+  - **phase:** `planning` | `implementation` | `integration`
+  - **type:** `ac-ambiguity` | `missing-context` | `tool-failure` | `rule-conflict` | `scope-drift` | `pattern-gap` | `retry-loop`
+  - **signal:** `low` (one-off) | `medium` (could recur) | `high` (systemic, will recur)
+  - **Rule F1:** Omit section if no friction. Empty tables are forbidden.
+  - **Rule F4:** Log environment friction (ACs, context, tooling, rules), not self-assessment.
 
 ---
 

--- a/.gaai/core/agents/sub-agents/micro-delivery.sub-agent.md
+++ b/.gaai/core/agents/sub-agents/micro-delivery.sub-agent.md
@@ -69,6 +69,9 @@ Includes:
 - Change summary
 - Acceptance criteria result (PASS / FAIL / ESCALATE)
 - Remediation log if applicable (max 2 attempts)
+- **Friction Log** (if any friction occurred — omit if smooth):
+
+  Same table format as Implementation Friction Log.
 
 ---
 

--- a/.gaai/core/agents/sub-agents/qa.sub-agent.md
+++ b/.gaai/core/agents/sub-agents/qa.sub-agent.md
@@ -80,6 +80,9 @@ Always writes: `contexts/artefacts/qa-reports/{id}.qa-report.md`
 - Per-criterion result (pass/fail with evidence)
 - Rule violations (if any)
 - Remediation attempts log (if applicable)
+- **Friction Log** (only if `remediate-failures` was invoked at least once — omit on clean PASS):
+
+  Same table format as Implementation Friction Log. Use `type: retry-loop` for QA failures, plus the root cause type if identifiable (e.g., `pattern-gap` if the failure stemmed from a missing coding pattern).
 - Escalation reason (if ESCALATE)
 
 On PASS only: `contexts/artefacts/memory-deltas/{id}.memory-delta.md`

--- a/.gaai/core/contexts/rules/memory.rules.md
+++ b/.gaai/core/contexts/rules/memory.rules.md
@@ -9,7 +9,7 @@ tags:
   - determinism
   - agent_control
 created_at: 2026-02-09
-updated_at: 2026-02-09
+updated_at: 2026-03-01
 ---
 
 # 🧠 GAAI Memory Rules
@@ -108,11 +108,45 @@ All files under `contexts/memory/sessions/` MUST:
 
 Session memory MUST NEVER be treated as durable knowledge.
 
-### R7 — Compaction Is Mandatory
+### R7 — Compaction Is Category-Aware
 
-If a memory file exceeds ~300–500 words, becomes outdated, or duplicates newer knowledge:
-- a summary MUST be created
-- the original MUST be moved to `archive/`
+Memory categories have different durability:
+
+**Durable memory** (decisions, patterns, project, ops, contacts, domains):
+- Entries MUST NEVER be archived based on file size alone
+- Only entries with an explicit supersession marker (R7b) may be archived
+- Oversized files → domain-split (e.g., `decisions/_log.md` → `decisions/{domain}.decisions.md`)
+- Summaries are INDEX-ONLY — they list entries for quick scanning but MUST NOT substitute for full text
+
+**Ephemeral memory** (sessions):
+- Standard 24–48h compaction applies (R6)
+- Summaries replace originals after compaction
+- Originals archived
+
+### R7b — Supersession Is the Only Archive Gate for Durable Memory
+
+Machine-readable markers determine archivability:
+- `> SUPERSEDED by DEC-XX` — replaced by a newer decision
+- `> RETRACTED` — withdrawn, no replacement
+- `> OBSOLETE — {reason}` — no longer applicable
+
+Rules:
+- No marker → ACTIVE → MUST NOT be archived
+- Marker present → may be moved to `archive/` during compaction
+- Oversized durable files → domain-split, never archive active entries
+
+### R7c — Contexts Lifecycle Guards
+
+**Backlog:**
+- Done items removed from `active.backlog.yaml` only when: (1) done ≥30 days, AND (2) no non-done item depends on it
+- Items with active dependents MUST remain visible regardless of age
+
+**Artefacts:**
+- Story and epic artefacts are permanent (reference material for future agents)
+- Strategy artefacts archive only when explicitly superseded by a newer version
+
+**Rules:**
+- Core rules (`core/contexts/rules/`) are never archived
 
 ## 🔁 Memory Maintenance
 

--- a/.gaai/core/skills/cross/decision-extraction/SKILL.md
+++ b/.gaai/core/skills/cross/decision-extraction/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: decision-extraction
 description: Identify and formalize durable product and technical decisions from agent outputs into long-term memory. Activate after Discovery produces artefacts, Delivery resolves trade-offs, or product direction materially changes.
-license: ELv2
+license: MIT
 compatibility: Works with any filesystem-based AI coding agent
 metadata:
   author: gaai-framework
@@ -9,14 +9,15 @@ metadata:
   category: cross
   track: cross-cutting
   id: SKILL-DECISION-EXTRACTION-001
-  updated_at: 2026-01-27
+  updated_at: 2026-03-01
   status: stable
 inputs:
   - recent_agent_outputs: session outputs from the invoking agent, or file paths to artefacts produced in the current session (e.g., evaluation reports, refined stories, approach-evaluation outputs)
   - contexts/artefacts/**  (governed)
 outputs:
-  - contexts/memory/decisions/*.memory.md
-  - contexts/memory/index.md  (updated)
+  - contexts/memory/decisions/DEC-{N}.md  (individual ADR file per DEC-138)
+  - contexts/memory/decisions/_log.md  (next ID updated)
+  - contexts/memory/index.md  (registry + file count updated)
 ---
 
 # Decision Extraction
@@ -35,43 +36,55 @@ Do NOT use for trivial steps, implementation details, brainstorming, or reversib
 
 ## Process
 
+0. **Decision Consistency Gate (mandatory, DEC-130).** Before extracting any new decision:
+   - Read `contexts/memory/index.md` → scan the Decision Registry by domain to identify relevant existing decisions
+   - Load the specific `decisions/DEC-{ID}.md` files for decisions in the affected domain(s)
+   - Verify the proposed decision does NOT contradict any active decision
+   - If contradiction found: either explicitly supersede (set `superseded_by` in old file + `supersedes` in new file) with rationale, or STOP and escalate to human
+   - If unable to determine consistency → STOP and escalate to human
+   - Never record a decision silently if it may conflict with an existing one
+
 1. Scan outputs for explicit or implicit decisions: architectural choices, accepted trade-offs, scope boundaries, prioritization shifts, constraints introduced
 2. Filter strictly for **durable, governance-relevant decisions**
-3. **Deduplication check:** Before writing a new decision entry, scan `contexts/memory/decisions/` for existing entries covering the same topic. If found: (a) if the new decision supersedes the old, update the existing entry's `updated_at` and add a `supersedes` note; (b) if the new decision confirms the old, skip writing a duplicate.
-4. Convert each into a structured Decision Memory entry:
+3. **Deduplication check:** Scan the Decision Registry in `index.md` for existing entries covering the same topic. If found: (a) if the new decision supersedes the old, update the old `DEC-{ID}.md` file's frontmatter (`status: superseded`, `superseded_by: DEC-{new-id}`) and record the supersession in the new entry's `supersedes` field; (b) if the new decision confirms the old, skip writing a duplicate.
+4. Convert each into a structured ADR file (see Output Format below):
    - Context
    - Decision
-   - Rationale
    - Impact
-5. Tag consistently — use tags from this controlled list: `product`, `architecture`, `scope`, `priority`, `billing`, `security`, `integration`, `infrastructure`. Add new tags only if none of these fit.
-6. Register in memory index
+5. Classify using the **10 canonical domains**: `architecture`, `matching`, `expert-system`, `billing`, `booking`, `infrastructure`, `strategy`, `governance`, `market`, `content`. And **3 levels**: `strategic` (WHAT/WHY), `architectural` (HOW), `operational` (PROCESS).
+6. **Get next available ID** from `decisions/_log.md` → write `decisions/DEC-{N}.md`
+7. **Update `_log.md`:** increment next available ID, add one-line entry for the new decision
+8. **Update `index.md`:** add row to Decision Registry, increment file count in Shared Categories table
 
 ---
 
-## Output Format
+## Output Format (DEC-138)
 
-Each decision file:
+Each decision is an individual ADR file: `decisions/DEC-{N}.md` (sequential numeric ID).
 
 ```yaml
 ---
-type: memory
-category: decision
-id: DEC-YYYY-MM-DD-XX
-tags:
-  - product | architecture | scope | priority | billing | security | integration | infrastructure
+id: DEC-{N}
+domain: architecture | matching | expert-system | billing | booking | infrastructure | strategy | governance | market | content
+level: strategic | architectural | operational
+title: "Decision Title"
+status: active
+created_by: discovery
 created_at: YYYY-MM-DD
-updated_at: YYYY-MM-DD
+last_updated_by: discovery
+last_updated_at: YYYY-MM-DD
+supersedes: null          # or DEC-{old-id} if replacing
+superseded_by: null
+tags:
+  - {relevant tags}
 ---
 
-# Decision Title
+# DEC-{N} — Decision Title
 
 ## Context
 ...
 
 ## Decision
-...
-
-## Rationale
 ...
 
 ## Impact

--- a/.gaai/core/skills/cross/friction-retrospective/SKILL.md
+++ b/.gaai/core/skills/cross/friction-retrospective/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: friction-retrospective
+description: Scan delivery artefacts for friction log entries, detect recurring patterns, and produce retrospective reports. Invoked by Discovery Agent (never by Delivery) to identify systemic improvement opportunities from friction captured during delivery.
+license: MIT
+compatibility: Works with any filesystem-based AI coding agent
+metadata:
+  author: gaai-framework
+  version: "1.0"
+  category: cross
+  track: cross-cutting
+  id: SKILL-FRICTION-RETROSPECTIVE-001
+  updated_at: 2026-03-01
+  status: experimental
+inputs:
+  - contexts/artefacts/impl-reports/**
+  - contexts/artefacts/qa-reports/**
+  - contexts/artefacts/delivery/**
+  - scope_filter (optional): epic, date_range, or friction_type
+outputs:
+  - retrospective_report (contexts/artefacts/retrospectives/{scope}.retro.md or inline)
+---
+
+# Friction Retrospective
+
+## Purpose / When to Activate
+
+Activate to aggregate and analyze friction captured during delivery. This skill reads `## Friction Log` sections from delivery artefacts and detects patterns that warrant promotion to durable memory (conventions, decisions, rule updates).
+
+**Recommended triggers (conventions, not rules):**
+- **Per-Epic:** when an Epic is marked done
+- **Monthly:** alongside `memory-refresh`
+- **Incident:** if a single Story generates 3+ friction events
+
+**Constraint:** Only the Discovery Agent may invoke this skill. Delivery agents capture friction; Discovery analyzes it.
+
+---
+
+## Process
+
+1. **Scope resolution** — determine which artefacts to scan:
+   - If `epic` filter: scan artefacts matching `{epic_id}S*`
+   - If `date_range` filter: scan artefacts within date range (from frontmatter `created_at`)
+   - If `type` filter: scan all artefacts but only extract entries matching the specified friction type
+   - If no filter: scan all artefacts (full retrospective)
+
+2. **Friction extraction** — for each artefact containing a `## Friction Log`:
+   - Parse the table rows
+   - Tag each entry with: Story ID (from filename), date (from frontmatter), artefact type (impl-report / qa-report / micro-delivery-report)
+
+3. **Pattern detection** — analyze extracted entries:
+   - Group by `type` (ac-ambiguity, missing-context, tool-failure, etc.)
+   - Count frequency per type
+   - Identify thematic clusters within each type (e.g., multiple `missing-context` about the same domain)
+   - Flag all entries with `signal: high`
+   - Flag types with frequency ≥ 3
+
+4. **Classify promotion candidates** — for entries meeting promotion threshold:
+   - `signal: high` → automatic promotion candidate (CAND-XXX)
+   - frequency ≥ 3 for same type+theme → promotion candidate
+   - Map each candidate to its promotion target (see Promotion Path below)
+
+5. **Produce the report** — structured in 4 sections:
+   - **Pattern Summary:** type distribution, top themes, overall friction density
+   - **High-Signal Events (CAND-XXX):** each candidate with evidence, proposed promotion target, and recommended action
+   - **Low-Signal Events:** grouped by type, listed for awareness
+   - **Retrospective Notes:** observations, cross-cutting themes, questions for human review
+
+6. **Write or return** — if scope is named (epic or date range), write to `contexts/artefacts/retrospectives/{scope}.retro.md`; otherwise return inline
+
+---
+
+## Promotion Path
+
+| Friction type | Promotion target | Destination file |
+|---|---|---|
+| `missing-context` (pattern) | New coding pattern | `patterns/conventions.md` |
+| `missing-context` (decision) | New decision | `decisions/DEC-{ID}.md` |
+| `ac-ambiguity` (recurring) | Story template or Discovery rule | `orchestration.rules.md` or `_template.story.md` |
+| `pattern-gap` | New code pattern | `patterns/conventions.md` |
+| `rule-conflict` | Rule clarification | `orchestration.rules.md` |
+| `tool-failure` (systemic) | Ops note or infra decision | `ops/platform.md` or new DEC |
+| `retry-loop` (≥3 same domain) | QA pattern | `patterns/conventions.md` |
+
+**Important:** This skill identifies candidates and recommends actions. Actual promotion to memory is performed by the Discovery Agent using `memory-ingest` — never automatically by this skill.
+
+---
+
+## Outputs
+
+- Retrospective report with pattern analysis
+- Promotion candidates (CAND-XXX) with evidence and recommended targets
+- Friction density metrics (events per Story, per type)
+
+---
+
+## Quality Checks
+
+- Every CAND-XXX has at least 2 supporting evidence entries (or 1 with `signal: high`)
+- Promotion targets are specific (file path + section), not vague
+- Low-signal events are listed but never promoted
+- Report does not contain implementation fixes — only identifies what to fix and where
+
+---
+
+## Non-Goals
+
+This skill must NOT:
+- Write to memory directly (it produces candidates; Discovery promotes)
+- Modify rules, conventions, or decisions
+- Re-run or remediate delivery — it is purely analytical
+- Assign blame to agents or sub-agents

--- a/.gaai/core/skills/cross/memory-compact/SKILL.md
+++ b/.gaai/core/skills/cross/memory-compact/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: memory-compact
 description: Emergency single-pass memory compression when context window pressure is high mid-task. Activate when approaching token limits during active work. For scheduled end-of-phase cleanup, use memory-refresh instead.
-license: ELv2
+license: MIT
 compatibility: Works with any filesystem-based AI coding agent
 metadata:
   author: gaai-framework
@@ -9,7 +9,7 @@ metadata:
   category: cross
   track: cross-cutting
   id: SKILL-MEMORY-COMPACT-001
-  updated_at: 2026-01-27
+  updated_at: 2026-03-01
   status: stable
 inputs:
   - contexts/memory/index.md
@@ -37,9 +37,13 @@ More focused than `memory-refresh` — this is a single-pass compression operati
 
 1. **Select memory by category or tags.** Read `contexts/memory/index.md`. Prioritize categories by: (a) largest file count first, (b) oldest entries first, (c) categories not referenced by the current task last. Under extreme pressure, compact the single largest category only.
 
-2. Extract key decisions, constraints, priorities
+2. **Classify entries by durability (R7 gate).** Before compacting, classify each entry:
+   - **Durable** (decisions, patterns, project, ops, contacts, domains): only entries with explicit supersession markers (`> SUPERSEDED by DEC-XX`, `> RETRACTED`, `> OBSOLETE — {reason}`) may be archived. All other entries are ACTIVE and MUST NOT be archived regardless of file size. Note: decisions are already individual ADR files per DEC-138 (`decisions/DEC-{N}.md`). For other oversized durable files → domain-split, not archive.
+   - **Ephemeral** (sessions): standard compaction applies — summarize and archive.
 
-3. **Generate a single summary file replacing multiple entries.** Produce one summary file per compacted category using bullet format: one bullet per decision, constraint, or durable fact. Target ≤20% of the original token count. Use the format:
+3. Extract key decisions, constraints, priorities
+
+4. **Generate a single summary file replacing multiple entries.** Produce one summary file per compacted category using bullet format: one bullet per decision, constraint, or durable fact. Target ≤20% of the original token count. Use the format:
 
 ```markdown
 # {Category} — Compact Summary
@@ -57,9 +61,9 @@ More focused than `memory-refresh` — this is a single-pass compression operati
 - {fact 1}
 ```
 
-4. **Archive detailed originals.** Archive originals to `contexts/memory/archive/{category}-{YYYY-MM-DD}.archive.md`. If multiple compactions happen on the same day for the same category, append a sequence number: `{category}-{YYYY-MM-DD}-02.archive.md`.
+5. **Archive detailed originals (ephemeral and superseded only).** Archive originals to `contexts/memory/archive/{category}-{YYYY-MM-DD}.archive.md`. If multiple compactions happen on the same day for the same category, append a sequence number: `{category}-{YYYY-MM-DD}-02.archive.md`.
 
-5. Update memory index
+6. Update memory index
 
 ---
 
@@ -79,6 +83,7 @@ More focused than `memory-refresh` — this is a single-pass compression operati
 - Index reflects current state
 - Summary preserves all active decisions and constraints from the originals
 - Archive files are never deleted — only moved
+- **No active durable memory entry archived** — only superseded/retracted entries may be archived (R7/R7b)
 
 ---
 

--- a/.gaai/core/skills/cross/memory-refresh/SKILL.md
+++ b/.gaai/core/skills/cross/memory-refresh/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: memory-refresh
 description: Periodic memory maintenance — archive session files, convert recurring knowledge into summaries, update the memory index. Activate at end of a major phase (Discovery complete, sprint done) or when memory spans many sessions. For emergency context-window pressure mid-task, use memory-compact instead.
-license: ELv2
+license: MIT
 compatibility: Works with any filesystem-based AI coding agent
 metadata:
   author: gaai-framework
@@ -9,7 +9,7 @@ metadata:
   category: cross
   track: cross-cutting
   id: SKILL-MEMORY-REFRESH-001
-  updated_at: 2026-02-26
+  updated_at: 2026-03-01
   status: stable
 inputs:
   - contexts/memory/index.md        (registry — read first to discover all active categories)
@@ -39,7 +39,9 @@ This skill governs and optimizes **existing memory only** — it does not create
 2. Extract durable knowledge from session memory
 3. Convert recurring or validated information into summary memory
 4. Archive raw session files to `contexts/memory/archive/`
-5. Compact oversized memory files
+5. **Compact with R7 category-aware rules:**
+   - **Durable memory** (decisions, patterns, project, ops, contacts, domains): only entries with explicit supersession markers (`> SUPERSEDED by DEC-XX`, `> RETRACTED`, `> OBSOLETE — {reason}`) may be archived. All other entries are ACTIVE and MUST NOT be archived. Decisions are already individual ADR files per DEC-138 (`decisions/DEC-{N}.md`) — no compaction needed. For other oversized durable files → domain-split, not archive.
+   - **Ephemeral memory** (sessions): standard compaction — summarize and archive.
 6. Update memory index
 
 ---
@@ -51,6 +53,7 @@ This skill governs and optimizes **existing memory only** — it does not create
 - Raw exploration is archived, not deleted
 - No uncontrolled memory growth
 - Index always reflects current active memory
+- **No active durable memory entry archived** — only superseded/retracted entries may be archived (R7/R7b)
 
 ---
 

--- a/.gaai/core/skills/cross/memory-retrieve/SKILL.md
+++ b/.gaai/core/skills/cross/memory-retrieve/SKILL.md
@@ -1,18 +1,18 @@
 ---
 name: memory-retrieve
-description: Load only the minimum relevant memory for a task by filtering the memory index by relevance. Activate before context-building — never load full memory dumps.
-license: ELv2
+description: Load only the minimum relevant memory for a task using 3-level progressive disclosure. Activate before context-building — never load full memory dumps. Never substitute summaries for durable memory.
+license: MIT
 compatibility: Works with any filesystem-based AI coding agent
 metadata:
   author: gaai-framework
-  version: "1.0"
+  version: "2.0"
   category: cross
   track: cross-cutting
   id: SKILL-MEMORY-RETRIEVE-001
-  updated_at: 2026-01-27
+  updated_at: 2026-03-01
   status: stable
 inputs:
-  - contexts/memory/index.md        (registry — read first to discover available categories)
+  - contexts/memory/index.md        (registry — always read first, contains Decision Registry + file map)
   - contexts/memory/**              (any category registered in index.md — resolved at runtime)
 outputs:
   - memory_context_bundle
@@ -25,16 +25,56 @@ outputs:
 Activate before `context-building` whenever a task requires historical context.
 
 **Never load full memory. Always filter by relevance.**
+**Never substitute summaries for durable memory (decisions, patterns, project).**
+
+---
+
+## 3-Level Progressive Disclosure
+
+```
+Level 1 — INDEX SCAN (~5 tokens/entry)
+  Read index.md → Decision Registry table (DEC | Domain | Level | Title)
+  Agent identifies relevant decision(s) by domain and/or level
+
+Level 2 — INDIVIDUAL ADR FILES (~300 tokens/file)
+  Load specific decisions/DEC-{ID}.md files for full entry text
+  Load other relevant category files (patterns, project, ops)
+
+Level 3 — CROSS-DOMAIN SCAN (only for Decision Consistency Gate)
+  Grep frontmatter across all DEC-*.md files for conflicts
+  Only triggered when recording a new decision (DEC-130)
+```
 
 ---
 
 ## Process
 
-1. Read memory index (`contexts/memory/index.md` — registry that maps categories to files). If `index.md` is absent or empty, fall back to scanning the `contexts/memory/` directory structure directly — enumerate subdirectories as categories.
-2. Identify relevant categories for the current task. Filter first by category (coarse), then by tags within selected categories (fine-grained) in Step 4.
-3. Prefer summaries when present (lower token cost)
-4. Within the selected categories, filter by tags or scope to narrow to the minimum relevant files.
-5. Load only selected files
+1. **Read memory index** (`contexts/memory/index.md`). This contains:
+   - Shared categories table (paths + purpose)
+   - Decision Registry: one row per DEC-ID with domain, level, and title
+   If `index.md` is absent or empty, fall back to scanning `contexts/memory/` directory structure.
+
+2. **Identify relevant decisions** for the current task:
+   - Filter the Decision Registry by **domain** (e.g., `billing`, `matching`)
+   - Filter by **level** if scope is known (e.g., only `architectural` for implementation tasks)
+   - From story/epic tags or explicit instruction scope
+
+3. **Load memory by durability class:**
+
+   **Durable memory** (decisions, patterns, project, ops, contacts, domains):
+   → Load individual `decisions/DEC-{ID}.md` files directly. Full text, never summaries.
+   → Summaries exist as INDEX-ONLY aids — they list entries for scanning but MUST NOT substitute for the full decision text.
+   → Load only the specific decisions relevant to the task (typically 3-10 files).
+
+   **Ephemeral memory** (sessions):
+   → Prefer summaries if available (lower token cost).
+
+4. **For Decision Consistency Gate (DEC-130):**
+   → Scan the Decision Registry in index.md for ALL entries in the relevant domain
+   → Load the specific `DEC-{ID}.md` files to check for conflicts
+   → If uncertain about boundaries, also load decisions from adjacent domains
+
+5. **Return `memory_context_bundle`** — curated, minimal set of memory files relevant to the current task.
 
 ---
 
@@ -48,8 +88,10 @@ Activate before `context-building` whenever a task requires historical context.
 
 - No full memory injection
 - Context is focused on the task
-- Summaries preferred over raw files
-- Token usage remains low
+- Agent loads only the specific DEC-{ID}.md files relevant to the task (typically 3-10)
+- **Summaries are NEVER substituted for durable memory** (decisions, patterns, project)
+- Decision Registry enables decision identification WITHOUT opening individual files
+- Token budget: index (~1,500) + 3-10 individual decision files (~300 each) = ~4,500 tokens typical
 - Only memory directly relevant to the task is included
 
 ---
@@ -60,5 +102,6 @@ This skill must NOT:
 - Load all memory files
 - Decide what to do with retrieved memory
 - Modify memory files
+- Substitute summary one-liners for full decision text
 
-**Selective retrieval is the golden rule. Memory is never auto-loaded.**
+**Selective retrieval via progressive disclosure. Memory is never auto-loaded. Durable memory is never summarized away.**


### PR DESCRIPTION
## Summary

- **Friction Log System:** Structured friction capture in delivery sub-agent artefacts (implementation, QA, micro-delivery) with controlled vocabulary (phase/type/signal). New `friction-retrospective` cross skill for Discovery-side pattern detection.
- **Context Lifecycle Audit:** Aligned `decision-extraction`, `memory-compact`, `memory-refresh`, `memory-retrieve` skills with individual ADR file format. Fixed outdated references to domain-split decision files and old frontmatter format.
- **Memory Rules (R7/R7b):** Updated `memory.rules.md` with explicit supersession-only archiving guards and individual ADR awareness.

## Files changed (9)

| File | Change |
|---|---|
| `agents/sub-agents/implementation.sub-agent.md` | Friction log in Handoff Artefact |
| `agents/sub-agents/qa.sub-agent.md` | Conditional friction log |
| `agents/sub-agents/micro-delivery.sub-agent.md` | Friction log |
| `skills/cross/friction-retrospective/SKILL.md` | NEW — Discovery-only retrospective skill |
| `skills/cross/decision-extraction/SKILL.md` | ADR format alignment (individual files, 10 domains, 3 levels) |
| `skills/cross/memory-compact/SKILL.md` | Fix outdated domain-split example |
| `skills/cross/memory-refresh/SKILL.md` | Fix outdated domain-split example |
| `skills/cross/memory-retrieve/SKILL.md` | v2.0 — 3-level progressive disclosure via Decision Registry |
| `contexts/rules/memory.rules.md` | R7/R7b supersession-only archiving guards |

## Test plan

- [x] `grep "Friction Log" agents/sub-agents/` → 3 matches
- [x] `ls skills/cross/friction-retrospective/SKILL.md` → exists
- [x] decision-extraction output format uses individual ADR files with domain/level metadata
- [x] memory-compact/refresh correctly reference individual ADR files
- [x] memory-retrieve uses 3-level progressive disclosure

🤖 Generated with [Claude Code](https://claude.com/claude-code)