### PR TITLE
feat(create-skill): mandatory index update step

### DIFF
--- a/.gaai/README.md
+++ b/.gaai/README.md
@@ -1,39 +1,25 @@
-# GAAI — Start Here
+# .gaai/ — GAAI Framework (v2.0.0)
 
-This project uses GAAI — a governance layer for AI coding tools.
-
-**If you are a human:** read the next two sections, then tell your AI tool to read this file.
-**If you are an AI agent:** read this entire file. It contains your operating instructions.
-
----
-
-## What's Inside
+## Directory Structure
 
 ```
 .gaai/
-├── core/       ← the framework (don't edit)
-└── project/    ← YOUR project data (edit everything here)
+├── core/       ← Framework (synced with GAAI OSS repo via git subtree)
+├── project/    ← Project-specific data (memory, backlog, artefacts, custom skills)
+└── README.md   ← This file
 ```
 
-**`core/`** — agents, skills, rules, workflows. The engine.
-**`project/`** — backlog, memory, decisions, artefacts. Your data.
+- `core/` is **git subtree**-synced with the [GAAI-framework](https://github.com/Fr-e-d/GAAI-framework) OSS repo
+- `project/` is **local only** — never synced to OSS
 
 ---
 
-## Get Started (Human)
+## Core Principle
 
-**First time?** Tell your AI tool:
-
-> *"Read `.gaai/README.md` and bootstrap this project."*
-
-**Daily use — two commands:**
-
-1. **`/gaai-discover`** — describe what you want. Gets turned into a Story with acceptance criteria.
-2. **`/gaai-deliver`** — the agent builds it. Planning, implementation, QA — autonomous.
-
-> [Quick Reference](QUICK-REFERENCE.md) — slash commands and daily workflows
-> [Full Guide](GAAI.md) — architecture, principles, deep reference
-> [Online Docs](https://github.com/Fr-e-d/GAAI-framework/tree/main/docs) — guides and design decisions
+**Your project changes DO NOT auto-sync to OSS.** All syncing is explicit and intentional:
+- `.gaai/core/` changes stay local until you choose to contribute
+- `.gaai/project/` is always 100% local (never pushed to OSS)
+- Updates from OSS are pulled on-demand
 
 ---
 
@@ -50,45 +36,198 @@ Full reference: see `GAAI.md` → "Branch Model & Automation".
 
 ---
 
-## AI Operating Instructions
+## Contributing Framework Improvements
 
-**You are operating under GAAI governance.** The instructions below apply to any AI coding tool — Claude Code, OpenCode, Codex CLI, Gemini CLI, Cursor, Windsurf, Antigravity, or any other.
+When you improve `.gaai/core/` in this project, you can contribute those changes back to the OSS repo.
 
-### Your Identity
+### Option 1: Patch-Based Contribution ⭐ (RECOMMENDED)
 
-You operate as one of three agents depending on context:
+**Simplest, cleanest, zero git history pollution.**
 
-- **Discovery Agent** — when clarifying intent, creating artefacts, defining what to build
-  → Read `.gaai/core/agents/discovery.agent.md` before acting
-- **Delivery Agent** — when implementing validated Stories from the backlog
-  → Read `.gaai/core/agents/delivery.agent.md` before acting
-- **Bootstrap Agent** — when initializing or refreshing project context on a new codebase
-  → Read `.gaai/core/agents/bootstrap.agent.md` before acting
+```bash
+# Extract your .gaai/core/ changes into a patch file
+gaai-framework-contrib.sh --patch
 
-### Five Rules (Non-Negotiable)
+# Follow the prompt to:
+# 1. Review changes
+# 2. Create a descriptive message
+# 3. Export as patch file
+# 4. Open PR on GAAI-framework repo
 
-1. **Every execution unit must be in the backlog.** Check `.gaai/project/contexts/backlog/active.backlog.yaml` before starting work.
-2. **Every agent action must reference a skill.** Read the skill file before invoking it. Skills index: `.gaai/core/skills/README.skills.md`
-3. **Memory is explicit.** Load only what is needed. Never auto-load all memory.
-4. **Artefacts document — they do not authorize.** Only the backlog authorizes execution.
-5. **When in doubt, stop and ask.**
+# The patch is then manually applied in the OSS repo
+```
 
-### Key Files
+**Manual version:**
+```bash
+# Extract changes since last sync
+git format-patch gaai-framework/main..HEAD -- .gaai/core/ \
+  -o /tmp/gaai-contrib.patch
 
-| Purpose | File |
-|---|---|
-| Framework orientation | `.gaai/GAAI.md` |
-| Orchestration rules | `.gaai/core/contexts/rules/orchestration.rules.md` |
-| Skills catalog | `.gaai/core/skills/README.skills.md` |
-| Active backlog | `.gaai/project/contexts/backlog/active.backlog.yaml` |
-| Project memory | `.gaai/project/contexts/memory/project/context.md` |
-| Decision log | `.gaai/project/contexts/memory/decisions/_log.md` |
-| Conventions | `.gaai/project/contexts/memory/patterns/conventions.md` |
+# Send to GAAI-framework repo (via PR or email)
+# OSS maintainer applies: git apply /tmp/gaai-contrib.patch
+```
 
-### First Session Logic
+**Why this works:**
+- ✅ OSS repo history stays clean
+- ✅ No subtree conflicts
+- ✅ Clear PR review
+- ✅ Works across multiple projects (A, B, C, ...)
 
-If `project/contexts/memory/project/context.md` contains only placeholder text:
-→ Activate as **Bootstrap Agent**. Read `core/agents/bootstrap.agent.md` and follow `core/workflows/context-bootstrap.workflow.md`.
+---
 
-If project memory is already populated:
-→ Check the backlog. If the user wants to build something, activate as **Discovery Agent**. If a refined Story is ready, activate as **Delivery Agent**.
+### Option 2: Git Subtree Push (Advanced)
+
+**Direct push to OSS repo. Requires write access.**
+
+```bash
+# Push your .gaai/core/ changes to a contribution branch
+git subtree push --prefix=.gaai gaai-framework contrib/<your-project-name>
+
+# Then:
+# 1. Create a PR on GAAI-framework: contrib/<your-project-name> → main
+# 2. OSS maintainer merges (handles the unrelated-history merge once)
+# 3. CI auto-splits main → _subtree-export
+```
+
+**Caveats:**
+- ⚠️ First push per project requires `--allow-unrelated-histories` handling
+- ⚠️ More git knowledge required
+- ✅ More direct if you have write access
+
+---
+
+## Pulling Framework Updates
+
+### From `main` (after a contribution is merged)
+
+```bash
+# Pull latest improvements from OSS repo
+git subtree pull --prefix=.gaai gaai-framework main --squash
+```
+
+### Version pinning (advanced)
+
+```bash
+# Pin to a specific release tag (e.g., v2.1.0)
+git subtree pull --prefix=.gaai gaai-framework v2.1.0 --squash
+```
+
+---
+
+## Setup
+
+### One-time: Add the OSS remote
+
+```bash
+git remote add gaai-framework https://github.com/Fr-e-d/GAAI-framework.git
+git fetch gaai-framework
+```
+
+### One-time: Initialize .gaai/ subtree (new projects only)
+
+```bash
+git subtree add --prefix=.gaai gaai-framework main --squash
+```
+
+---
+
+## Workflow Diagram
+
+```
+Your Project (A or B)              GAAI-framework OSS Repo
+─────────────────────              ───────────────────────
+
+.gaai/ modifications (excl. project/)
+       │
+       ├─→ Option 1: PATCH-BASED ⭐
+       │   └─→ gaai-framework-contrib.sh --patch
+       │       └─→ Send patch to OSS repo (PR)
+       │           └─→ Merged into main
+       │
+       └─→ Option 2: SUBTREE PUSH (advanced)
+           └─→ git subtree push --prefix=.gaai gaai-framework contrib/your-project
+               └─→ Create PR contrib/your-project → main
+                   └─→ Merged into main
+
+                                    main branch
+                                        ↓
+                          (Your .gaai/ changes are now in main!)
+                                        ↓
+                          Pull updates back anytime:
+                          git subtree pull --prefix=.gaai \
+                            gaai-framework main --squash
+```
+
+---
+
+## Helper Script: `gaai-framework-contrib.sh`
+
+Simplifies the patch-based contribution workflow.
+
+Located in: **`~/.claude/scripts/gaai-framework-contrib.sh`** (user-level, not in git repos)
+
+```bash
+# Review and create a patch from your changes
+gaai-framework-contrib.sh --patch
+
+# Or directly push (requires write access)
+gaai-framework-contrib.sh --push
+
+# View status
+gaai-framework-contrib.sh --status
+```
+
+**Why user-level?** The script lives in your home directory (outside any git repo) to prevent tampering. If it lived in `.gaai/scripts/`, someone with write access to the project could modify it to inject malicious code.
+
+### Setup (one-time)
+
+```bash
+# Verify installation
+ls -la ~/.claude/scripts/gaai-framework-contrib.sh
+
+# If not found, copy from project documentation
+# (See .gaai/scripts/README.md for installation)
+```
+
+See `.gaai/scripts/README.md` and `CONTRIBUTING-GAAI.md` for full documentation.
+
+---
+
+## Multi-Project Scenario
+
+When working on **multiple projects (A, B, C)** simultaneously:
+
+| Scenario | Best Approach |
+|----------|---------------|
+| Same improvement needed in A and B | Patch from A → merge into OSS → pull into B |
+| Different improvements in A and B | Each sends own patch → OSS merges both |
+| Bug fix in A affects B | Fix in A → patch to OSS → B pulls latest |
+| Experimenting in B, don't want to share yet | Keep local in B, sync later when ready |
+
+**Key:** OSS `main` becomes the "source of truth" for shared improvements.
+
+---
+
+## FAQ
+
+**Q: What if I accidentally commit `.gaai/project/` changes?**
+A: They stay local. Only `.gaai/core/` is eligible for OSS contribution via patch/push.
+
+**Q: Can multiple projects contribute to OSS simultaneously?**
+A: Yes! Each sends a patch. OSS repo merges them sequentially (no conflicts).
+
+**Q: What if OSS has merged someone else's changes?**
+A: Just run `git subtree pull --prefix=.gaai gaai-framework main --squash` to get them.
+
+**Q: Do I need write access to GAAI-framework for patch contribution?**
+A: No. Create a PR with the patch file. Maintainer applies it.
+
+---
+
+## Branching Strategy
+
+|                     | Your Project | GAAI OSS                                           |
+|---------------------|---------------------|------|
+| Main branch         | `main` / `staging`            | `main`  |
+| Contribution method | Patch-based (recommended) | PR merge  |
+| Update source       | `gaai-framework/main` via `git subtree pull` | — |

--- a/.gaai/core/skills/cross/create-skill/SKILL.md
+++ b/.gaai/core/skills/cross/create-skill/SKILL.md
@@ -140,11 +140,25 @@ Optional subdirectories (create only if needed):
 - `references/` — supporting documents the skill references
 - `assets/` — templates or static files the skill produces
 
-### Step 6 — Regenerate the skills index
+### Step 6 — Update ALL relevant indices (MANDATORY)
 
-Invoke `build-skills-index` (`.gaai/core/skills/cross/build-skills-index/SKILL.md`) to regenerate `.gaai/core/skills/skills-index.yaml` from the updated frontmatter.
+This step is non-negotiable. A skill that is not indexed is invisible to agents.
 
-Do not manually edit `skills-index.yaml` — it is a derived artifact.
+**6a. Skills index YAML:**
+- Core skills: invoke `build-skills-index` to regenerate `.gaai/core/skills/skills-index.yaml`
+- Project skills: invoke `build-skills-indices` to regenerate `.gaai/project/skills/skills-index.yaml`
+- Verify the new skill appears in the generated index with correct `id`, `name`, `path`, and `tags`
+
+**6b. Skills README:**
+- Core skills: update `.gaai/core/skills/README.skills.md` — add the skill to the appropriate category section
+- Project skills: update `.gaai/project/skills/README.md` — add the skill to the appropriate section
+
+**6c. Domain index (if domain-scoped skill):**
+- If the skill belongs to a domain (e.g., `domains/content-production/`), update the domain's `index.md` in memory:
+  - `.gaai/project/contexts/memory/domains/{domain}/index.md` — add a row to the skills table
+- This ensures domain sub-agents discover the skill when loading their domain context
+
+**Failure to update any of these indices means the skill is effectively invisible** — agents cannot discover it, and it will not be loaded during delivery or discovery sessions.
 
 ### Step 7 — Reference in agent file
 

--- a/.gaai/core/skills/skills-index.yaml
+++ b/.gaai/core/skills/skills-index.yaml
@@ -2,10 +2,10 @@
 # Source of truth: .gaai/core/skills/*/SKILL.md and .gaai/project/skills/*/SKILL.md
 # Regenerate: invoke build-skills-indices skill
 
-generated_at: 2026-03-03
-total: 56
+generated_at: 2026-03-05
+total: 62
 core: 47
-project: 9
+project: 15
 
 discovery:
   - id: SKILL-CNT-011
@@ -17,14 +17,14 @@ discovery:
     tags: []
     updated_at: 2026-02-26
     path: project/skills/domains/content-production/content-plan/SKILL.md
-  - id: SKILL-CNT-012
+  - id: SKILL-CNT-001
     name: content-research
     source: project
     description: "Research-first content creation protocol. Triggers before writing any content piece. Performs deep search to map current search intent, audience pain points, existing content landscape, and information gaps. Produces a structured research brief that feeds into drafting. Implements Content-Market-Fit methodology, Pain Point SEO, and the Content Cyborg model. Mandatory prerequisite for all hub content — AI training data is stale at draft time, only live research produces current, relevant content."
     category: content
     track: discovery
     tags: []
-    updated_at: 2026-03-02
+    updated_at: 2026-03-05
     path: project/skills/domains/content-production/content-research/SKILL.md
   - id: SKILL-CREATE-PRD-001
     name: create-prd
@@ -109,6 +109,33 @@ delivery:
     tags: []
     updated_at: 2026-02-18
     path: core/skills/delivery/compose-team/SKILL.md
+  - id: SKILL-CNT-003
+    name: content-draft
+    source: project
+    description: "Write the first draft of a content piece from a validated outline. Applies voice guide, audience perception files, and humanization techniques. Produces prose that is audience-aligned, source-backed, and detection-resistant. Implements the Content Cyborg model — AI elaborates, human provides structure and original insight."
+    category: content
+    track: delivery
+    tags: []
+    updated_at: 2026-03-05
+    path: project/skills/domains/content-production/content-draft/SKILL.md
+  - id: SKILL-CNT-004
+    name: content-edit
+    source: project
+    description: "Editorial review and humanization pass on a first draft. Performs three editing passes — structural, line-level, and authenticity. Catches factual errors, voice violations, redundancy, and AI tells. Produces a publication-ready draft. Implements the Content Cyborg principle — the editorial layer is where human judgment is most critical."
+    category: content
+    track: delivery
+    tags: []
+    updated_at: 2026-03-05
+    path: project/skills/domains/content-production/content-edit/SKILL.md
+  - id: SKILL-CNT-002
+    name: content-outline
+    source: project
+    description: "Transform a research brief into a structured article outline. Maps intent, audience awareness stage, and persuasion model to heading hierarchy. Produces a section-by-section blueprint with word targets, source assignments, and CTA placement. Prerequisite for CNT-003 (drafting). Never outline without a brief."
+    category: content
+    track: delivery
+    tags: []
+    updated_at: 2026-03-05
+    path: project/skills/domains/content-production/content-outline/SKILL.md
   - id: SKILL-DEL-009
     name: coordinate-handoffs
     source: core
@@ -145,6 +172,15 @@ delivery:
     tags: []
     updated_at: 2026-03-01
     path: core/skills/delivery/frontend-design/SKILL.md
+  - id: SKILL-CNT-006
+    name: geo-optimize
+    source: project
+    description: "Generative Engine Optimization pass on content. Optimizes for AI search citation (Perplexity, ChatGPT, Google AIO, Brave) by applying GEO-specific interventions — answer-first structure, citation density, entity alignment, specificity premium, and machine-readable freshness signals. Runs after or alongside SEO-optimize (CNT-005). Distinct from traditional SEO because GEO citation is decoupled from organic rankings."
+    category: content
+    track: delivery
+    tags: []
+    updated_at: 2026-03-05
+    path: project/skills/domains/content-production/geo-optimize/SKILL.md
   - id: SKILL-CNT-012
     name: google-trends
     source: project
@@ -181,6 +217,15 @@ delivery:
     tags: []
     updated_at: 2026-02-26
     path: core/skills/delivery/qa-review/SKILL.md
+  - id: SKILL-CNT-009
+    name: quality-gate
+    source: project
+    description: "Final quality gate before publication. Validates that a content piece meets all pipeline standards — editorial, SEO, authenticity, brand, and credibility. Produces a pass/fail verdict with specific remediation actions for any failures. This is the last automated check before human approval."
+    category: content
+    track: delivery
+    tags: []
+    updated_at: 2026-03-05
+    path: project/skills/domains/content-production/quality-gate/SKILL.md
   - id: SKILL-REMEDIATE-FAILURES-001
     name: remediate-failures
     source: core
@@ -199,6 +244,15 @@ delivery:
     tags: []
     updated_at: 2026-02-26
     path: project/skills/domains/content-production/repurpose/SKILL.md
+  - id: SKILL-CNT-005
+    name: seo-optimize
+    source: project
+    description: "On-page SEO and GEO optimization pass on an edited draft. Applies technical SEO checklist (meta tags, structured data, internal links, image alt text) and Generative Engine Optimization (answer capsules, citation density, semantic HTML). Does not change editorial content — optimizes discoverability without compromising readability."
+    category: content
+    track: delivery
+    tags: []
+    updated_at: 2026-03-05
+    path: project/skills/domains/content-production/seo-optimize/SKILL.md
   - id: SKILL-CNT-007
     name: social-adapt
     source: project
@@ -258,7 +312,7 @@ cross:
   - id: build-skills-indices
     name: build-skills-indices
     source: core
-    description: ""
+    description: "Scan SKILL.md files in .gaai/core/skills/ and .gaai/project/skills/, extract YAML frontmatter, and regenerate a single unified skills index for fast discovery across all skill repositories."
     category: governance
     track: cross-cutting
     tags: []
@@ -312,7 +366,7 @@ cross:
   - id: SKILL-DECISION-EXTRACTION-001
     name: decision-extraction
     source: core
-    description: "Identify and formalize durable product and technical decisions from agent outputs into long-term memory. Activate after Discovery produces artefacts, Delivery resolves trade-offs, or product direction materially changes. Always runs after Delivery QA PASS — mandatory gate includes updating index.md."
+    description: "Identify and formalize durable product and technical decisions from agent outputs into long-term memory. Activate after Discovery produces artefacts, Delivery resolves trade-offs, or product direction materially changes."
     category: cross
     track: cross-cutting
     tags: []
@@ -336,6 +390,15 @@ cross:
     tags: []
     updated_at: 2026-02-26
     path: project/skills/cross/domain-knowledge-research/SKILL.md
+  - id: SKILL-PRJ-001
+    name: framework-sync
+    source: project
+    description: "Sync the GAAI framework between this project and the GAAI-framework OSS repo via git subtree. Covers pull (OSS → project), push (project → OSS), and status check."
+    category: cross
+    track: cross-cutting
+    tags: []
+    updated_at: 2026-02-28
+    path: project/skills/cross/framework-sync/SKILL.md
   - id: SKILL-FRICTION-RETROSPECTIVE-001
     name: friction-retrospective
     source: core
@@ -357,7 +420,7 @@ cross:
   - id: i18n-extract
     name: i18n-extract
     source: core
-    description: ""
+    description: "Scan codebase for hardcoded strings that should be internationalised, classify by domain and priority, and produce a structured extraction report for translation workflows."
     category: analysis
     track: cross-cutting
     tags: []
@@ -366,7 +429,7 @@ cross:
   - id: i18n-glossary-sync
     name: i18n-glossary-sync
     source: core
-    description: ""
+    description: "Maintain a canonical i18n glossary file — sync new terms across all language pairs, detect drift, flag missing translations, and enforce consistent terminology across the codebase."
     category: analysis
     track: cross-cutting
     tags: []
@@ -375,7 +438,7 @@ cross:
   - id: i18n-validate
     name: i18n-validate
     source: core
-    description: ""
+    description: "Validate translation completeness and consistency across all locale files — detect missing keys, untranslated strings, format mismatches, and glossary violations."
     category: analysis
     track: cross-cutting
     tags: []
@@ -384,7 +447,7 @@ cross:
   - id: idiomatique-translate
     name: idiomatique-translate
     source: core
-    description: ""
+    description: "Translate strings idiomatically across multiple target languages using a project glossary, preserving tone, domain terminology, and format placeholders while flagging untranslatable content."
     category: content
     track: cross-cutting
     tags: []
@@ -408,6 +471,15 @@ cross:
     tags: []
     updated_at: 2026-03-01
     path: core/skills/cross/memory-compact/SKILL.md
+  - id: SKILL-MEMORY-INDEX-SYNC-001
+    name: memory-index-sync
+    source: core
+    description: "Detect and heal index.md drift — finds memory files on disk not registered in index.md and registers them. Run when /gaai-status reports unregistered files, after batch memory operations, or as a post-delivery gate."
+    category: cross
+    track: cross-cutting
+    tags: []
+    updated_at: 2026-03-03
+    path: core/skills/cross/memory-index-sync/SKILL.md
   - id: SKILL-MEMORY-INGEST-001
     name: memory-ingest
     source: core
@@ -417,19 +489,6 @@ cross:
     tags: []
     updated_at: 2026-02-26
     path: core/skills/cross/memory-ingest/SKILL.md
-  - id: SKILL-MEMORY-INDEX-SYNC-001
-    name: memory-index-sync
-    source: core
-    description: "Detect and heal index.md drift — finds memory files on disk not registered in index.md and registers them. Run when /gaai-status reports unregistered files, after batch memory operations, or as a post-delivery gate."
-    category: cross
-    track: cross-cutting
-    tags:
-      - memory
-      - index
-      - sync
-      - governance
-    updated_at: 2026-03-03
-    path: core/skills/cross/memory-index-sync/SKILL.md
   - id: SKILL-MEMORY-REFRESH-001
     name: memory-refresh
     source: core


### PR DESCRIPTION
## Summary
- Step 6 in `create-skill/SKILL.md` now enforces 3 mandatory index updates after every skill creation
- Without all 3 indices updated, skills are invisible to agents
- Discovered in Callibrate when 7 new content pipeline skills were created but not indexed

## Changes
- `.gaai/core/skills/cross/create-skill/SKILL.md` — expanded Step 6 (3 sub-steps)
- `.gaai/core/skills/skills-index.yaml` — regenerated
- `.gaai/README.md` — sync

## Test plan
- [ ] Verify create-skill SKILL.md Step 6 has 3 sub-steps (6a, 6b, 6c)
- [ ] Verify skills-index.yaml is valid YAML

🤖 Generated with [Claude Code](https://claude.com/claude-code)