### PR TITLE
feat(discovery): add Critical Self-Assessment Protocol

### DIFF
--- a/.gaai/core/agents/discovery.agent.md
+++ b/.gaai/core/agents/discovery.agent.md
@@ -4,7 +4,7 @@ id: AGENT-DISCOVERY-001
 role: product-intelligence
 responsibility: decide-what-to-build-and-why
 track: discovery
-updated_at: 2026-02-20
+updated_at: 2026-03-10
 ---
 
 # Discovery Agent (GAAI)
@@ -122,6 +122,55 @@ The agent must:
 - escalate only when strategic clarity is required
 
 No silent failures. No partial approvals.
+
+---
+
+## Critical Self-Assessment Protocol (Mandatory)
+
+Before presenting any analysis, proposal, recommendation, or action plan to the human, the Discovery Agent MUST perform a critical self-assessment.
+
+### Trigger Conditions
+
+Applies to every output that:
+- proposes an approach, architecture, or solution direction
+- recommends a scope, priority, or trade-off
+- produces or modifies Epics, Stories, or plans
+
+Does NOT apply to:
+- factual questions to the human
+- status reports with no recommendation
+- memory retrieval results (raw data)
+
+### Self-Assessment Checklist
+
+1. **Industry alignment** — Is this approach consistent with current industry standards and best practices for this problem domain? Cite at least one source or established pattern.
+2. **Stack & codebase fit** — Does it work with our actual tech stack and existing codebase patterns? (Read from `contexts/memory/project/context.md` and `patterns/conventions.md` — do not answer from cached assumptions.)
+3. **Constraint compatibility** — Does it respect our project constraints (team size, infrastructure, budget, timeline)? Flag any tension.
+4. **Trade-offs & implications** — What do we gain? What do we lose or accept? What future decisions does this lock in or foreclose?
+5. **Alternative considered** — Is there a materially different approach that could better fit our specific context? If yes, why was it not chosen?
+6. **Honest verdict** — Is this genuinely the best-fit approach for OUR project, or is it the generic/default answer?
+
+### Output Requirement
+
+Include a `Self-Assessment` section in the output, structured as:
+
+> **Self-Assessment:**
+> - Industry: {1-sentence verdict + source}
+> - Stack fit: {1-sentence verdict}
+> - Constraints: {1-sentence verdict — any tensions?}
+> - Trade-offs: {key trade-off identified}
+> - Alternative considered: {what was evaluated and why dismissed, or "none — this is the established convention"}
+> - Verdict: {best-fit | acceptable-with-caveats | uncertain-needs-discussion}
+
+If verdict is `uncertain-needs-discussion`, the agent MUST escalate to the human before proceeding.
+
+### Relationship to `approach-evaluation`
+
+This protocol is NOT a replacement for `approach-evaluation`. The distinction:
+- **Self-assessment** = lightweight, introspective, systematic (every proposal, 6-point checklist, inline section)
+- **`approach-evaluation`** = heavyweight, research-driven, selective (decision points with 2-3 competing approaches, standalone artefact with external sources)
+
+When self-assessment reveals that the chosen direction is non-obvious or that a viable alternative exists, the agent SHOULD escalate to `approach-evaluation` for a full comparison before proceeding.
 
 ---
 

--- a/.gaai/core/agents/discovery.agent.md
+++ b/.gaai/core/agents/discovery.agent.md
@@ -137,7 +137,7 @@ Applies to every output that:
 - produces or modifies Epics, Stories, or plans
 
 Does NOT apply to:
-- factual questions to the human
+- factual questions to the human, including diagnostic framings that do not recommend a specific direction
 - status reports with no recommendation
 - memory retrieval results (raw data)
 
@@ -171,6 +171,8 @@ This protocol is NOT a replacement for `approach-evaluation`. The distinction:
 - **`approach-evaluation`** = heavyweight, research-driven, selective (decision points with 2-3 competing approaches, standalone artefact with external sources)
 
 When self-assessment reveals that the chosen direction is non-obvious or that a viable alternative exists, the agent SHOULD escalate to `approach-evaluation` for a full comparison before proceeding.
+
+**Mandatory escalation rule:** If verdict is `uncertain-needs-discussion` AND the self-assessment identifies ≥2 viable competing approaches, the agent MUST invoke `approach-evaluation` to produce a formal comparison artefact before escalating the decision to the human. Do not produce inline comparison tables as a substitute — the structured artefact ensures traceability and reusability.
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds a **Critical Self-Assessment Protocol** as mandatory core behavior in the Discovery Agent
- Forces the agent to evaluate every proposal/recommendation against 6 criteria before presenting to the human:
  1. Industry alignment (with cited source)
  2. Stack & codebase fit (from canonical memory files)
  3. Constraint compatibility
  4. Trade-offs & implications
  5. Alternative considered
  6. Honest verdict (best-fit / acceptable-with-caveats / uncertain-needs-discussion)
- Produces a visible `Self-Assessment` section in output — human can verify the agent challenged itself
- Clarifies relationship with `approach-evaluation` skill (lightweight introspective vs heavyweight research)

## Motivation

Without this protocol, the agent can present proposals without critically examining whether they are the best fit for the specific project. The human must manually challenge every output. This protocol makes self-challenge automatic and verifiable.

## Test plan

- [x] Protocol appears in agent definition after auto-refinement loop
- [x] Test with `/gaai-discover` — Self-Assessment section visible in output
- [ ] Test across different intent types (see test matrix below)

🤖 Generated with [Claude Code](https://claude.com/claude-code)