### PR TITLE
fix(installer): resolve chicken-and-egg pre-flight check blocking fre…

### DIFF
--- a/.gaai/core/scripts/install-check.sh
+++ b/.gaai/core/scripts/install-check.sh
@@ -98,14 +98,24 @@ else
   check ".gaai/ in target — ok (not present, clean install)" "ok"
 fi
 
-# 6. Git hooks
+# 6. Git repository
+echo ""
+echo "[ Git Repository ]"
+if (cd "$TARGET" && git rev-parse --git-dir &>/dev/null); then
+  check "target is a git repository" "ok"
+else
+  check "target is a git repository" "not a git repo — run 'git init' first"
+fi
+
+# 7. Git hooks (informational — installer will configure these)
 echo ""
 echo "[ Git Hooks ]"
 HOOKS_PATH=$(cd "$TARGET" && git config --get core.hooksPath 2>/dev/null || echo "")
 if [[ "$HOOKS_PATH" == ".githooks" ]]; then
   check "core.hooksPath set to .githooks" "ok"
 else
-  check "core.hooksPath" "not set to .githooks (installer will configure this)"
+  echo "  ⚠️  core.hooksPath not set to .githooks (installer will configure this)"
+  PASS=$((PASS + 1))
 fi
 
 if [[ -d "$TARGET/.githooks" ]]; then
@@ -113,11 +123,13 @@ if [[ -d "$TARGET/.githooks" ]]; then
     if [[ -x "$TARGET/.githooks/$dispatcher" ]]; then
       check ".githooks/$dispatcher dispatcher" "ok"
     else
-      check ".githooks/$dispatcher dispatcher" "missing or not executable (installer will create it)"
+      echo "  ⚠️  .githooks/$dispatcher dispatcher — missing or not executable (installer will create it)"
+      PASS=$((PASS + 1))
     fi
   done
 else
-  check ".githooks/ directory" "not present (installer will create it)"
+  echo "  ⚠️  .githooks/ directory — not present (installer will create it)"
+  PASS=$((PASS + 1))
 fi
 
 # Summary


### PR DESCRIPTION
…sh installs

The pre-flight check counted missing git hooks (core.hooksPath, .githooks/ directory, dispatchers) as failures, even though the installer itself creates them. This blocked installation on any fresh project.

Changes:
- Git hooks checks are now warnings (⚠️) instead of failures — consistent with the existing .gaai/ directory check pattern
- Added a hard check for "target is a git repository" since that is a true prerequisite the installer cannot fix

# Pull Request

## Type of change

- [ ] Bug fix (broken behavior in an existing file)
- [ ] Documentation fix (typo, unclear explanation, broken link)
- [ ] Other (describe below)

## What does this PR change?

A brief description of what was wrong and what this fixes.

## Files changed

List the files modified and why.

## Testing

How was this tested?
- [ ] Ran `bash .gaai/core/scripts/health-check.sh --core-dir .gaai/core` — passes
- [ ] Reviewed affected documentation for accuracy

---

**Note:** GAAI uses a Fork & Own model. This repo accepts bug fixes and documentation corrections only. New skills, new agents, and framework feature additions are not accepted upstream — implement them in your own fork. See [CONTRIBUTING.md](../CONTRIBUTING.md).
