### PR TITLE
docs(E19S03): correct false tool-agnostic claims — 3-tier compatibility model

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ AI coding tools are fast — but without governance, speed creates drift: agents
 
 **Delivery** — always runs in an **isolated process**. `/gaai-deliver` launches the Delivery Daemon, which runs each Story in its own `claude -p` session via tmux — a completely separate OS process with no Discovery residue and no conversation history bleed. The Delivery Agent orchestrates specialized sub-agents (Planning, Implementation, QA) per Story. Real-time visibility via `tmux attach`. No improvisation. No scope drift. No context contamination.
 
+`claude -p` (Claude Code CLI) is a **runtime dependency** for autonomous delivery. The daemon requires the `claude` binary in PATH. This applies whether you use GAAI OSS or GAAI Cloud — Discovery and governance are tool-agnostic, autonomous delivery is not.
+
 **The backlog is the contract.** Nothing gets built that isn't in it.
 
 ```
@@ -171,7 +173,9 @@ bash .gaai/core/scripts/daemon-setup.sh
 
 > `/gaai-deliver` and `/gaai-daemon` are aliases — use whichever you prefer.
 
-> Requires: git repo, `staging` branch, an AI coding tool with `/gaai-*` slash commands (e.g. [Claude Code](https://claude.com/claude-code)), python3, tmux (recommended) or Terminal.app (macOS fallback).
+> Requires: git repo, `staging` branch, **Claude Code CLI (`claude` in PATH)**, python3, tmux (recommended) or Terminal.app (macOS fallback).
+>
+> **Note:** The Delivery Daemon requires the `claude` binary regardless of which AI tool you use for Discovery. Discovery and governance work with any tool — autonomous delivery requires Claude Code CLI.
 >
 > **Tested on:** macOS (Apple Silicon). Linux and WSL (Windows) are expected to work but not yet validated — issues and feedback welcome.
 
@@ -197,7 +201,7 @@ bash .gaai/core/scripts/daemon-setup.sh
 | Windsurf | `AGENTS.md` |
 | Any other | Read `.gaai/core/README.md` directly |
 
-One canonical source (`.gaai/`). Thin adapters per tool. No duplication. The framework functions identically across all tools — the difference is activation convenience, not capability.
+One canonical source (`.gaai/`). Thin adapters per tool. No duplication. Discovery, governance, and manual delivery work with any AI coding tool. Autonomous delivery (the Delivery Daemon) requires Claude Code CLI (`claude` in PATH) as a local runtime — this applies whether you use GAAI OSS or GAAI Cloud.
 
 > [Full compatibility details](docs/reference/tool-compatibility.md)
 

--- a/docs/reference/tool-compatibility.md
+++ b/docs/reference/tool-compatibility.md
@@ -17,7 +17,9 @@ GAAI works with any AI coding tool that can read files. This document covers set
 | Windsurf | ❌ | Via `AGENTS.md` | Manual | `AGENTS.md` |
 | Any other | ❌ | Manual | Manual | Read `.gaai/README.md` directly |
 
-**Claude Code** has the deepest integration. All other tools provide full GAAI capability via manual activation — the framework works identically, the difference is convenience.
+**Claude Code** has the deepest integration. All other tools provide full GAAI capability for Discovery and governance via manual activation — the difference is convenience.
+
+> **Delivery Daemon:** Regardless of which tool you use for Discovery, the Delivery Daemon requires **Claude Code CLI (`claude` in PATH)** as a runtime dependency. Discovery and governance work with any tool in the matrix above; autonomous delivery requires Claude Code CLI.
 
 ---
 
@@ -151,17 +153,27 @@ For any tool that supports reading project files:
 1. Copy the relevant content from `.gaai/core/compat/claude-code.md` or `.gaai/core/compat/windsurf.md` as a system prompt or instructions file for your tool
 2. Use manual prompts to activate agents
 
-The framework functions correctly regardless of how it's activated — the files are the system. The compat adapters only make activation more convenient.
+The framework's governance files are the system — they work with any AI tool for Discovery and governance. The compat adapters only make activation more convenient. The one exception: the Delivery Daemon requires Claude Code CLI (`claude` in PATH) as a runtime dependency for autonomous delivery.
 
 ---
 
-## The Framework Is Tool-Agnostic
+## Tool Compatibility: 3-Tier Model
 
-GAAI's governance is in the files, not in the tool. Changing AI tools requires only:
+GAAI tool compatibility follows a 3-tier model:
+
+| Tier | Mode | Requirement |
+|---|---|---|
+| 1 | Discovery / governance (interactive) | Any AI coding tool or MCP client |
+| 2 | Delivery interactive (manual) | Any AI coding tool or MCP client |
+| 3 | Delivery autonomous (daemon) | Claude Code CLI (`claude` in PATH) |
+
+**Discovery and governance are tool-agnostic.** GAAI's governance is in the files. Changing AI tools for Discovery or governance requires only:
 1. Deploying the right compat adapter (the installer handles this)
 2. Using the appropriate activation method (slash command vs manual prompt)
 
 All memory, rules, backlog, and artefacts remain unchanged.
+
+**Autonomous delivery requires Claude Code CLI.** The Delivery Daemon runs `claude -p` as a background OS process. This is a runtime dependency — not a tool choice. You can use any AI tool for Discovery and still use autonomous delivery, as long as Claude Code CLI is installed locally. This applies to both GAAI OSS and GAAI Cloud users.
 
 ---
 


### PR DESCRIPTION
## Summary
- Replace misleading "framework functions identically across all tools" language with an accurate 3-tier model statement in `README.md` (Works With section, Delivery Daemon section, How It Works section)
- Add explicit Delivery Daemon requirement note below the Compatibility Matrix in `tool-compatibility.md`
- Rewrite "The Framework Is Tool-Agnostic" section as "Tool Compatibility: 3-Tier Model" with a table and factual dependency statement

## Test Results
- No code changed — documentation only
- All 7 acceptance criteria verified by QA review: PASS

## Changes Delivered
| File | Purpose |
|------|---------|
| `README.md` | AC1 (Works With), AC2 (Delivery Daemon Requires), AC3 (How It Works) |
| `docs/reference/tool-compatibility.md` | AC4 (Matrix note), AC5 (3-tier section), AC6 (Other Tools correction), AC7 (no spin) |

## Story
- ID: E19S03
- Artefact: .gaai/project/contexts/artefacts/stories/E19S03.story.md
- Related DEC: DEC-34 (3-tier tool compatibility model, platform-wide)

🤖 Generated with [GAAI Delivery Agent](https://github.com/Fr-e-d/GAAI-framework)