### PR TITLE
docs(changelog): scope E101S07a entries to OSS daemon work only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,13 +18,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - feat(governance): SKILL-RIN-001 review-input + anti-girouette research bundle
-- feat(E101S07a): daemon HMAC signing + webhook secret provisioning (#466)
+- feat(E101S07a): daemon HMAC-SHA256 signing of outbound webhook POSTs (X-Hub-Signature-256 + X-Webhook-Source headers, GAAI_DAEMON_WEBHOOK_SECRET env var)
 
 
 ## [2.19.0] - 2026-04-25
 
 ### Changed
-- feat(E101S07a): daemon HMAC signing + webhook secret provisioning endpoint
+- feat(E101S07a): daemon HMAC-SHA256 signing of outbound webhook POSTs (X-Hub-Signature-256 + X-Webhook-Source headers, GAAI_DAEMON_WEBHOOK_SECRET env var)
 - fix(daemon-monitor): classify nested claude -p (Implement Agent) as sub-agent
 - feat(daemon-monitor): surface sub-agent activity + fix "Bash null" rendering
 - fix(framework): use .gaai-worktrees/ naming to avoid in-project .gaai/ collision


### PR DESCRIPTION
## Summary

Strip `+ webhook secret provisioning [endpoint]` from the v2.19.0 and v2.20.0 entries for `feat(E101S07a)`. That half of the original commit subject referred to `PUT /api/v1/workspaces/:id/webhook-secrets/:source` — a Cloud-side REST endpoint (`workers/gaai-cloud/api/src/rest/workspaces.ts`) that **never ships to GAAI-framework** via `sync-framework-to-oss.sh` (only `.gaai/core/` is snapshotted).

Per **DEC-70** (gaai-oss and gaai-cloud are independent products), the OSS CHANGELOG must describe only what an OSS user can install and use without running gaai-cloud.

## Diff

Both lines rewritten to:
> `feat(E101S07a): daemon HMAC-SHA256 signing of outbound webhook POSTs (X-Hub-Signature-256 + X-Webhook-Source headers, GAAI_DAEMON_WEBHOOK_SECRET env var)`

This describes exactly what landed in `.gaai/core/scripts/delivery-daemon.sh` (compute_webhook_hmac helper + header injection at 4 call sites + env var declaration) and in `.gaai/core/scripts/tests/test-webhook-hmac.sh`.

## Root cause

Upstream commit `d3f5c347 feat(E101S07a): daemon HMAC signing + webhook secret provisioning (#466)` bundled OSS daemon edits (3 files in `.gaai/core/`) with a Cloud REST endpoint (2 files in `workers/gaai-cloud/`) into one PR/one commit. The auto-sync replays commit subjects verbatim into `CHANGELOG.md`, so the Cloud half leaked into OSS release notes.

Discipline patch in upstream `gaai-platform` repo (memory rule extended to forbid mixed-scope stories/commits — boundary check on cross-product diffs).

## Test plan

- [x] Verify diff only touches CHANGELOG.md (2 lines)
- [x] Confirm rewritten lines accurately describe what is in .gaai/core/scripts/delivery-daemon.sh at the relevant version
- [ ] Merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)