### PR TITLE
chore: wire the mandatory public-release gate into CI

### DIFF
--- a/.github/workflows/validate-structure.yml
+++ b/.github/workflows/validate-structure.yml
@@ -15,8 +15,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Validate .gaai/ structure
-        run: bash .gaai/core/scripts/health-check.sh
+      - name: Report checked-out ref
+        run: echo "Validating checked-out ref $(git rev-parse HEAD)"
 
-      - name: Validate artefact references
-        run: bash .gaai/core/scripts/artefact-sync.sh
+      - name: Validate public release
+        run: bash .gaai/core/scripts/validate-public-release.sh


### PR DESCRIPTION
Replaces the two-step \`health-check.sh\` + \`artefact-sync.sh\` CI call with a single call to \`validate-public-release.sh\` (synced from the upstream project's \`.gaai/core/\`), which runs both existing gates plus every hermetic shell test under \`scripts/tests/\` and every Node test under \`adapters/**/__tests__/\`, discovered from the filesystem in lexical order, fail-fast — no manifest, no expected count.

Also adds an explicit "Report checked-out ref" step so the validated commit is visible in CI evidence.

Note: turning this gate on is expected to surface a pre-existing test failure in \`crash-recovery.test.sh\` that predates this change (verified byte-identical to the prior synced content) — that is the class of gap this gate exists to surface, and fixing it is tracked separately.