### PR TITLE
docs: state ELv2 licensing precisely, remove open-source wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ One canonical source (`.gaai/`). Thin adapters per tool. No duplication. Discove
 - Discovery is conversational and intentionally lightweight. It helps you structure what you know — it does not replace deep product research or collaborative brainstorming across a team.
 - Trivial tasks still need a backlog item. You can make it a one-liner, but the gate is always there.
 - The framework relies on the agent following the files. There is no programmatic enforcement.
-- The repo is freshly open-sourced. Community is just getting started.
+- The repo was recently published under ELv2. Community is just getting started.
 
 ---
 
@@ -228,7 +228,7 @@ One canonical source (`.gaai/`). Thin adapters per tool. No duplication. Discove
 
 ---
 
-ELv2 — see [LICENSE](LICENSE)
+**source-available under the Elastic License 2.0 (ELv2)** — see [LICENSE](LICENSE) for the full terms.
 
 ---
 

--- a/docs/contributing/fork-and-own.md
+++ b/docs/contributing/fork-and-own.md
@@ -77,7 +77,7 @@ Most value from GAAI is in the structure and conventions — not in constantly f
 
 ## What We Ask
 
-GAAI is ELv2 licensed. You can do anything with your fork — the only restriction is you may not offer it as a competing hosted or managed service.
+GAAI is source-available under the Elastic License 2.0 (ELv2) — see [LICENSE](../../LICENSE) for the governing terms.
 
 If you find bugs or documentation errors in the upstream framework, please report them at [GitHub Issues](https://github.com/gaai-framework/gaai-framework/issues).
 


### PR DESCRIPTION
## Summary

- README's "Honest Trade-offs" section no longer describes the repo as "freshly open-sourced".
- README's licensing description now uses the canonical source-available phrasing, linked to LICENSE.
- `docs/contributing/fork-and-own.md`'s "What We Ask" section now names ELv2 and links to LICENSE for the governing terms, instead of paraphrasing the restriction.
- The license itself (ELv2) is unchanged — this is a terminology-only correction, verified against the tracked LICENSE hash.

## Test plan

- [x] `licensing-terminology.test.sh` run against this branch: 13/13 PASS (companion PR #653 already published the test to `main`)
- [x] `grep -niE 'open.source' README.md docs/contributing/fork-and-own.md` — no matches
- [x] `shasum -a 256 LICENSE` unchanged before/after

🤖 Generated with [Claude Code](https://claude.com/claude-code)