### PR TITLE
docs(readme): teach the privileged entry, drop the removed fallback, and describe the real stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,28 +151,45 @@ git clone https://github.com/Fr-e-d/GAAI-framework.git /tmp/gaai && \
 - Launches parallel Claude Code or Codex sessions in tmux (default: 3 slots, configurable)
 - Coordinates across devices via git push
 - Monitors health, retries failures, archives completed work
-- Auto-opens a monitoring dashboard (tmux split: daemon config + active deliveries)
+- Runs inside a private tmux server whose socket is digest-bound to the repository, so a second checkout can never join or clobber the lifecycle
+- Offers an on-demand monitoring dashboard (tmux split: daemon config + active deliveries)
 
 <img src="assets/daemon-monitor.png" alt="Delivery Daemon monitoring 3 concurrent story deliveries" width="700">
 
 **Setup (one-time):**
 
 ```bash
-bash .gaai/core/scripts/daemon-setup.sh
+.gaai/core/scripts/daemon-setup.sh
 ```
+
+Invoke it **directly**. `daemon-setup.sh` and `daemon-start.sh` are executables carrying a
+`#!/bin/bash -p` shebang: prefixing either with a plain `bash` interpreter is refused with
+`entry_authority_invalid`, because a non-privileged interpreter has already applied `BASH_ENV`
+and imported exported functions before the script's first instruction. The only alternative is
+an absolute, verified Bash invoked `--noprofile --norc -p <script>`.
+
+`daemon-setup.sh` is also the **only** command that may create or update the dedicated daemon
+home worktree. Startup verifies that home and refuses if it is absent, stale, dirty, foreign or
+on the wrong branch — it never repairs it, and there is no fallback to your working checkout.
+
+Because the entry rebuilds a closed allowlist of configuration, a shell exporting `GIT_EDITOR`,
+`GIT_CONFIG_COUNT`, `PYTHONPATH` and similar cannot start the daemon. That is the contract, not
+a defect — start it from a clean environment, e.g.
+`env -i PATH=/usr/bin:/bin HOME="$HOME" TERM="$TERM" .gaai/core/scripts/daemon-start.sh`.
 
 **Usage:**
 
 ```
-/gaai-daemon                        # start daemon (3 slots, auto-opens monitor)
+/gaai-daemon                        # start daemon (3 slots)
 /gaai-daemon --max-concurrent 3     # 3 parallel deliveries
-/gaai-daemon --status               # live monitoring dashboard
+/gaai-daemon --status               # read-only lifecycle status (mutates nothing)
+/gaai-daemon --monitor              # attach the monitoring dashboard
 /gaai-daemon --stop                 # graceful shutdown
 ```
 
 > `/gaai-deliver` = one Story, current session. `/gaai-daemon` = background daemon, parallel delivery.
 
-> Requires: git repo, `staging` branch, **Claude Code CLI (`claude` in PATH, default) or Codex CLI (`codex` in PATH, via `GAAI_DAEMON_EXECUTOR=codex`)**, python3, tmux (recommended) or Terminal.app (macOS fallback).
+> Requires: git repo, `staging` branch, **Claude Code CLI (`claude` in PATH, default) or Codex CLI (`codex` in PATH, via `GAAI_DAEMON_EXECUTOR=codex`)**, python3, and **tmux — required, not optional** (3.2 is the nominal floor; a real capability probe is the admission authority). There is no Terminal.app or `nohup` fallback: a fallback launcher is how process ownership used to be inferred from ambient state instead of proven.
 >
 > **Note:** The Delivery Daemon explicitly supports two local headless executors — Claude Code CLI (default) and Codex CLI. An unknown or unavailable executor stops before governed work begins with an actionable error. Discovery and governance work with any AI tool — this requirement applies only to autonomous delivery.
 >

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 ![Version](https://img.shields.io/badge/version-2.48.0-blue)
 ![License: ELv2](https://img.shields.io/badge/license-ELv2-green)
-![No SDK](https://img.shields.io/badge/stack-markdown%20%2B%20yaml%20%2B%20bash-orange)
+![Stack](https://img.shields.io/badge/stack-bash%20%2B%20md%20%2B%20yaml%20%2B%20python%20%2B%20node-orange)
 
 # GAAI — Governed Agentic AI Infrastructure
 
-A `.gaai/` folder you drop into any project. Markdown + YAML + bash. No SDK. No package. No external services.
+A `.gaai/` folder you drop into any git project. Markdown, YAML and bash, with a vendored Python runtime and a few Node helpers. No SDK. No package to install. No external services.
 
 **GAAI turns AI coding tools into reliable agentic software delivery systems.**
 
@@ -94,7 +94,7 @@ your-project/
             └── artefacts/     ← stories, epics, plans, reports
 ```
 
-No SDK. No npm package. No pip install. Markdown + YAML + bash. Readable by humans and any AI tool.
+No SDK. No npm package. No pip install — nothing is fetched when you install. Governance is markdown, YAML and bash: readable by humans and by any AI tool. Delivery also needs `python3` and `node` on PATH, plus the vendored PyYAML runtime shipped in `.gaai/core/vendor/` — the one binary in the tree.
 
 ---
 
@@ -189,7 +189,7 @@ a defect — start it from a clean environment, e.g.
 
 > `/gaai-deliver` = one Story, current session. `/gaai-daemon` = background daemon, parallel delivery.
 
-> Requires: git repo, `staging` branch, **Claude Code CLI (`claude` in PATH, default) or Codex CLI (`codex` in PATH, via `GAAI_DAEMON_EXECUTOR=codex`)**, python3, and **tmux — required, not optional** (3.2 is the nominal floor; a real capability probe is the admission authority). There is no Terminal.app or `nohup` fallback: a fallback launcher is how process ownership used to be inferred from ambient state instead of proven.
+> Requires: git repo, `staging` branch, **Claude Code CLI (`claude` in PATH, default) or Codex CLI (`codex` in PATH, via `GAAI_DAEMON_EXECUTOR=codex`)**, `python3`, `node`, and **tmux — required, not optional** (3.2 is the nominal floor; a real capability probe is the admission authority). There is no Terminal.app or `nohup` fallback: a fallback launcher is how process ownership used to be inferred from ambient state instead of proven.
 >
 > **Note:** The Delivery Daemon explicitly supports two local headless executors — Claude Code CLI (default) and Codex CLI. An unknown or unavailable executor stops before governed work begins with an actionable error. Discovery and governance work with any AI tool — this requirement applies only to autonomous delivery.
 >
@@ -227,6 +227,7 @@ One canonical source (`.gaai/`). Thin adapters per tool. No duplication. Discove
 
 - Discovery is conversational and intentionally lightweight. It helps you structure what you know — it does not replace deep product research or collaborative brainstorming across a team.
 - Trivial tasks still need a backlog item. You can make it a one-liner, but the gate is always there.
+- “No package to install” is literal, not a claim of zero dependencies. Nothing is fetched — PyYAML is vendored in-tree — but `git`, `python3`, `node` and `tmux` must already be on PATH for the Delivery Daemon, and the vendored runtime is a binary zipapp rather than readable source.
 - The framework relies on the agent following the files. There is no programmatic enforcement.
 - The repo was recently published under ELv2. Community is just getting started.
 


### PR DESCRIPTION
The separately governed public-repository correction that `E1003S07` (in `gaai-platform`) required before this framework can be declared safe to release or restart — plus a second, related honesty fix found while reviewing it.

## Why this file specifically

The root `README.md` is **public-only** — it has no counterpart in `gaai-platform` and is not covered by the `.gaai/core` sync. So while the synced `.gaai/core` surfaces already teach the privileged entry, this README kept teaching an invocation the framework now **refuses**, and a launcher that no longer exists.

A reader following it would run `bash .gaai/core/scripts/daemon-setup.sh`, get `entry_authority_invalid`, and have nothing to tell them why. That was the last actionable plain-Bash invocation anywhere in this repository.

## Commit 1 — the entry and the removed fallback

| Was | Now |
|---|---|
| `bash .gaai/core/scripts/daemon-setup.sh` | `.gaai/core/scripts/daemon-setup.sh`, invoked directly |
| "tmux (recommended) or Terminal.app (macOS fallback)" | **tmux required**; no Terminal.app or `nohup` fallback exists |
| "`--status` # live monitoring dashboard" | `--status` is read-only; `--monitor` attaches the dashboard |
| "auto-opens a monitoring dashboard" | nothing opens by itself; the daemon runs on a private, digest-bound tmux server |

Added, because it is the first thing a new operator will actually hit: both scripts are executables carrying a `#!/bin/bash -p` shebang, so a plain `bash` prefix is refused — a non-privileged interpreter has already applied `BASH_ENV` and imported exported functions before the script's first instruction. The only alternative is an absolute, verified Bash invoked `--noprofile --norc -p`.

Also stated plainly: `daemon-setup.sh` is the **only** command that may create or update the daemon home worktree; startup verifies it and refuses if it is absent, stale, dirty, foreign or wrong-branch, and never repairs it — there is no fallback to your working checkout.

And the consequence people will trip over: a shell exporting `GIT_EDITOR`, `GIT_CONFIG_COUNT`, `PYTHONPATH` and similar **cannot** start the daemon. That is the contract, not a defect, so the README now shows the clean-environment invocation.

## Commit 2 — "Markdown + YAML + bash" was not true

The tagline, the stack badge and the structure blurb all described the framework as *Markdown + YAML + bash*. A census of `.gaai/core` on this branch falsifies it:

| | |
|---|---|
| 125 `.md` · 113 `.sh` · 6 `.yaml` | as advertised |
| **8 production JavaScript files** | `lib/qa-verdict.mjs`, `lib/delivery-router.mjs`, `lib/delivery-provenance.mjs`, `lib/local-admission-{resolver,executor}.mjs`, `adapters/claude-code/{nested-claude-spawn,runtime-routing-logger}.js`, `scripts/check-and-update-skills-index.cjs` |
| **1 Python script** | `scripts/daemon-worktree-audit.py` |
| **219 KB vendored PyYAML 6.0.3 zipapp** | `vendor/pyyaml/6.0.3/pyyaml-runtime.pyz` |

They are load-bearing, not decoration: `delivery-daemon.sh` gates on `command -v node`, `daemon-dispatch.sh` invokes `node lib/qa-verdict.mjs`, and `install-check.sh` calls the YAML runtime tuple *"a hard check, not an optional one"*.

**What was accurate stays.** There is no `package.json`, no `node_modules` and no `requirements.txt` anywhere under `.gaai/core` — verified — so *No SDK / no npm package / no pip install* is literally true, and deliberately so: PyYAML is vendored precisely so nothing is fetched at install time. The defect was pairing that true claim with a stack description implying the interpreters were not needed either.

*"Readable by humans and any AI tool"* also could not stand unqualified, since the vendored runtime is a binary zipapp. It now scopes to the governance surface, which really is markdown, YAML and bash.

Two further gaps closed: `node` was missing from the Delivery Daemon prerequisites (which listed `python3` and tmux but never it), and **Honest Trade-offs** now records that "no package to install" is not a claim of zero dependencies.

## Census

A fresh repository-wide census over this repository finds **zero** actionable plain-Bash invocations of `daemon-start.sh` or `daemon-setup.sh`.

## Scope

Documentation only — one file, two commits. No code, no behaviour change. The `.gaai/core` tree here is maintained by the sync from `gaai-platform` and is untouched by this PR.

### Correction to an earlier claim in this description

This description previously said the `.gaai/core` tree here trailed `gaai-platform` by the `daemon-start.sh` / `daemon-setup.sh` / `lib/daemon-home.sh` changes from PRs 3177 and 3178. **That was wrong, and it is retracted.**

It was inferred from `.github/.last-auto-bump` on `staging`, which still points at `ec1588d` — a commit predating the entire E1003S07 chain. The marker is stale, not the tree: the sync had already run, and only its marker-bump commit has not landed back on `staging`.

Verified by direct comparison against `staging` instead of the marker — `daemon-start.sh`, `daemon-setup.sh`, `lib/daemon-home.sh`, `delivery-daemon.sh` and the three home test suites are byte-identical between the two repositories. Nothing from PRs 3175, 3177 or 3178 is pending sync.

The stale operator prose that `gaai-platform#3179` corrected in `.gaai/core/compat/commands/` reaches this repository through the sync, not through this PR.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YRcHKWWM3mAb4LNpzgmpFp