### PR TITLE
docs: state the platform support the pipeline now enforces

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,12 @@ a defect — start it from a clean environment, e.g.
 >
 > **Note:** The Delivery Daemon explicitly supports two local headless executors — Claude Code CLI (default) and Codex CLI. An unknown or unavailable executor stops before governed work begins with an actionable error. Discovery and governance work with any AI tool — this requirement applies only to autonomous delivery.
 >
-> **Tested on:** macOS (Apple Silicon). Linux and WSL (Windows) are expected to work but not yet validated — issues and feedback welcome.
+> **Tested on:** macOS (Apple Silicon), enforced on every candidate — the daemon home
+> suites run on a hosted macOS runner under `/bin/bash`, which on that platform is the
+> Bash 3.2 floor the daemon entry point targets. Linux (Ubuntu) is exercised by the
+> hosted corpus on the same candidates. WSL is **not** claimed — no WSL run exists.
+> Native Windows (Git Bash / MSYS2 / Cygwin) is unsupported: the daemon refuses to
+> start there. Issues and feedback welcome.
 
 ---
 


### PR DESCRIPTION
The root README claimed Linux and WSL are "expected to work but not yet validated". That is no longer accurate, and it contradicted the in-tree `.gaai/core/README.md` shipped in this same repository.

**What changed upstream.** Every candidate touching the framework now runs the three daemon home suites on a hosted **macOS** runner under `/bin/bash` — which on that platform *is* the Bash 3.2 floor the daemon entry point targets — and the aggregate authority job requires that lane. Linux (Ubuntu) is exercised by the hosted corpus on the same candidates.

That lane exists for a measured reason: a fully green Linux run once declared these suites healthy while the same code failed twenty-two assertions on a Mac. Darwin's kernel interfaces differ from Linux's in ways a `/proc`-based run cannot observe.

**What this PR does not claim.** WSL stays unclaimed — no WSL run exists. Native Windows (Git Bash / MSYS2 / Cygwin) stays unsupported, and the daemon refuses to start there rather than degrading silently.

Documentation only; no code, no workflow, no behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)